### PR TITLE
Configure IO port I as nonsecure, just as A-H

### DIFF
--- a/Projects/B-U585I-IOT02A/Applications/SBSFU/SBSFU_Boot/Src/boot_hal.c
+++ b/Projects/B-U585I-IOT02A/Applications/SBSFU/SBSFU_Boot/Src/boot_hal.c
@@ -119,6 +119,7 @@ void boot_platform_noimage(void)
     __HAL_RCC_GPIOF_CLK_ENABLE();
     __HAL_RCC_GPIOG_CLK_ENABLE();
     __HAL_RCC_GPIOH_CLK_ENABLE();
+    __HAL_RCC_GPIOI_CLK_ENABLE();
     GPIOA_S->SECCFGR = 0x0;
     GPIOB_S->SECCFGR = 0x0;
     GPIOC_S->SECCFGR = 0x0;
@@ -127,6 +128,7 @@ void boot_platform_noimage(void)
     GPIOF_S->SECCFGR = 0x0;
     GPIOG_S->SECCFGR = 0x0;
     GPIOH_S->SECCFGR = 0x0;
+    GPIOI_S->SECCFGR = 0x0;
 #if defined(MCUBOOT_PRIMARY_ONLY)
     /* loader code is set secure after control being set successfully */
     /* MPU allowing execution of this area is set after HDP activation */

--- a/Projects/B-U585I-IOT02A/Applications/TFM/TFM_Appli/Secure/Src/target_cfg.c
+++ b/Projects/B-U585I-IOT02A/Applications/TFM/TFM_Appli/Secure/Src/target_cfg.c
@@ -213,6 +213,7 @@ void pinmux_init_cfg(void)
   __HAL_RCC_GPIOF_CLK_ENABLE();
   __HAL_RCC_GPIOG_CLK_ENABLE();
   __HAL_RCC_GPIOH_CLK_ENABLE();
+  __HAL_RCC_GPIOI_CLK_ENABLE();
   GPIOA_S->SECCFGR = 0x0;
   GPIOB_S->SECCFGR = 0x0;
   GPIOC_S->SECCFGR = 0x0;
@@ -221,6 +222,7 @@ void pinmux_init_cfg(void)
   GPIOF_S->SECCFGR = 0x0;
   GPIOG_S->SECCFGR = 0x0;
   GPIOH_S->SECCFGR = 0x0;
+  GPIOI_S->SECCFGR = 0x0;
 #ifdef TFM_FIH_PROFILE_ON
   FIH_RET(fih_int_encode(TFM_PLAT_ERR_SUCCESS));
 #endif 

--- a/Projects/B-U585I-IOT02A/Applications/TFM/TFM_SBSFU_Boot/Src/boot_hal.c
+++ b/Projects/B-U585I-IOT02A/Applications/TFM/TFM_SBSFU_Boot/Src/boot_hal.c
@@ -120,6 +120,7 @@ void boot_platform_noimage(void)
     __HAL_RCC_GPIOF_CLK_ENABLE();
     __HAL_RCC_GPIOG_CLK_ENABLE();
     __HAL_RCC_GPIOH_CLK_ENABLE();
+    __HAL_RCC_GPIOI_CLK_ENABLE();
     GPIOA_S->SECCFGR = 0x0;
     GPIOB_S->SECCFGR = 0x0;
     GPIOC_S->SECCFGR = 0x0;
@@ -128,6 +129,7 @@ void boot_platform_noimage(void)
     GPIOF_S->SECCFGR = 0x0;
     GPIOG_S->SECCFGR = 0x0;
     GPIOH_S->SECCFGR = 0x0;
+    GPIOI_S->SECCFGR = 0x0;
 #if defined(MCUBOOT_PRIMARY_ONLY)
     /* loader code is set secure after control being set successfully */
     /* MPU allowing execution of this area is set after HDP activation */


### PR DESCRIPTION
I/O Port I is currently not configured as a nonsecure device in the TFM application.  The commits in this pull requests will fix that.

My company did sign a CLA and send it to your legal department on March, 25th 2022.