### PR TITLE
osEventFlagsWait with options

### DIFF
--- a/Middlewares/ST/cmsis_rtos_threadx/cmsis_os2.c
+++ b/Middlewares/ST/cmsis_rtos_threadx/cmsis_os2.c
@@ -2420,13 +2420,21 @@ uint32_t osEventFlagsWait(osEventFlagsId_t ef_id, uint32_t flags,
   }
   else
   {
-    if (options == osFlagsNoClear)
+    if ((options & osFlagsNoClear) == osFlagsNoClear)
     {
-      get_option = TX_AND;
+    	if ((options & osFlagsWaitAll) == osFlagsWaitAll) {
+    		get_option = TX_AND;
+    	} else {
+    		get_option = TX_OR;
+    	}
     }
     else
     {
-      get_option = TX_AND_CLEAR;
+      if ((options & osFlagsWaitAll) == osFlagsWaitAll) {
+    	  get_option = TX_AND_CLEAR;
+      } else {
+    	  get_option = TX_OR_CLEAR;
+      }
     }
     /* Call the tx_event_flags_get to get flags */
     status = tx_event_flags_get(eventflags_ptr, requested_flags, get_option, &actual_flags, wait_option);


### PR DESCRIPTION
osEventFlagsWait with wait options osFlagsWaitAny (OR) and osFlagsWaitAll (AND)

## IMPORTANT INFORMATION

### Contributor License Agreement (CLA)
* The Pull Request feature will be considered by STMicroelectronics after the signature of a **Contributor License Agreement (CLA)** by the submitter.
* If you did not sign such agreement, please follow the steps mentioned in the [CONTRIBUTING.md](https://github.com/STMicroelectronics/STM32CubeU5/blob/main/CONTRIBUTING.md) file.
