### PR TITLE
drivers: STM32U5 : ADC_LL : fix : fixed ADC4 channels sequence

### DIFF
--- a/Drivers/STM32U5xx_HAL_Driver/Inc/stm32u5xx_ll_adc.h
+++ b/Drivers/STM32U5xx_HAL_Driver/Inc/stm32u5xx_ll_adc.h
@@ -4443,7 +4443,7 @@ __STATIC_INLINE void LL_ADC_REG_SetSequencerLength(ADC_TypeDef *ADCx, uint32_t S
   }
   else
   {
-    SET_BIT(ADCx->CHSELR, SequencerNbRanks);
+    MODIFY_REG(ADCx->CHSELR, ADC_CHSELR_CHSEL,SequencerNbRanks);
   }
 }
 


### PR DESCRIPTION
If read 2 different channels in turn, CHSELR register will content two channels. Need erase register before write a new channel
The same behaviour for sequences.

## IMPORTANT INFORMATION

### Contributor License Agreement (CLA)
* The Pull Request feature will be considered by STMicroelectronics after the signature of a **Contributor License Agreement (CLA)** by the submitter.
* If you did not sign such agreement, please follow the steps mentioned in the [CONTRIBUTING.md](https://github.com/STMicroelectronics/STM32CubeU5/blob/main/CONTRIBUTING.md) file.
