### PR TITLE
Make ymodem compliant lrzsz

### DIFF
--- a/Projects/B-U585I-IOT02A/Applications/SBSFU/SBSFU_Appli/NonSecure/Src/fw_update_app.c
+++ b/Projects/B-U585I-IOT02A/Applications/SBSFU/SBSFU_Appli/NonSecure/Src/fw_update_app.c
@@ -43,8 +43,7 @@ extern ARM_DRIVER_FLASH LOADER_FLASH_DEV_NAME;
   * @{
   */
 static uint32_t m_uFileSizeYmodem = 0U;    /* !< Ymodem File size*/
-static uint32_t m_uNbrBlocksYmodem = 0U;   /* !< Ymodem Number of blocks*/
-static uint32_t m_uPacketsReceived = 0U;   /* !< Ymodem packets received*/
+static uint32_t m_uRemainData = 0U;    /* !< Ymodem File size*/
 static uint32_t m_uFlashSectorSize = 0U;   /* !< Flash Sector Size */
 static uint32_t m_uFlashMinWriteSize = 0U; /* !< FLash Min Write access*/
 /** @defgroup  FW_UPDATE_Private_Const Private Const
@@ -605,14 +604,10 @@ HAL_StatusTypeDef Ymodem_HeaderPktRxCpltCallback(uint32_t uFlashDestination, uin
 {
   /*Reset of the ymodem variables */
   m_uFileSizeYmodem = 0U;
-  m_uPacketsReceived = 0U;
-  m_uNbrBlocksYmodem = 0U;
 
   /*Filesize information is stored*/
   m_uFileSizeYmodem = uFileSize;
-
-  /* compute the number of 1K blocks */
-  m_uNbrBlocksYmodem = (m_uFileSizeYmodem + (PACKET_1K_SIZE - 1U)) / PACKET_1K_SIZE;
+  m_uRemainData = m_uFileSizeYmodem;
 
   /* NOTE : delay inserted for Ymodem protocol*/
   HAL_Delay(1000);
@@ -629,25 +624,11 @@ extern uint32_t total_size_received;
 HAL_StatusTypeDef Ymodem_DataPktRxCpltCallback(uint8_t *pData, uint32_t uFlashDestination, uint32_t uSize)
 {
   int32_t ret;
-  m_uPacketsReceived++;
 
-  /*Increase the number of received packets*/
-  if (m_uPacketsReceived == m_uNbrBlocksYmodem) /*Last Packet*/
-  {
-    /*Extracting actual payload from last packet*/
-    if (0 == (m_uFileSizeYmodem % PACKET_1K_SIZE))
-    {
-      /* The last packet must be fully considered */
-      uSize = PACKET_1K_SIZE;
-    }
-    else
-    {
-      /* The last packet is not full, drop the extra bytes */
-      uSize = m_uFileSizeYmodem - ((uint32_t)(m_uFileSizeYmodem / PACKET_1K_SIZE) * PACKET_1K_SIZE);
-    }
+  if (m_uRemainData - uSize < 1)
+	  uSize = m_uRemainData;
+  m_uRemainData -= uSize;
 
-    m_uPacketsReceived = 0U;
-  }
   /*Adjust dimension to 64-bit length */
   if (uSize %  m_uFlashMinWriteSize != 0U)
   {
@@ -669,8 +650,7 @@ HAL_StatusTypeDef Ymodem_DataPktRxCpltCallback(uint8_t *pData, uint32_t uFlashDe
   {
     /*Reset of the ymodem variables */
     m_uFileSizeYmodem = 0U;
-    m_uPacketsReceived = 0U;
-    m_uNbrBlocksYmodem = 0U;
+    m_uRemainData = 0U;
     return HAL_ERROR;
   }
   else

--- a/Projects/B-U585I-IOT02A/Applications/SBSFU/SBSFU_Appli/NonSecure/Src/ymodem.c
+++ b/Projects/B-U585I-IOT02A/Applications/SBSFU/SBSFU_Appli/NonSecure/Src/ymodem.c
@@ -35,7 +35,6 @@
 #include "main.h"
 
 /* Private const -------------------------------------------------------------*/
-const char BACK_SLASH_POINT[]="\b.";
 /* Private typedef -----------------------------------------------------------*/
 /* Private define ------------------------------------------------------------*/
 /* Private macro -------------------------------------------------------------*/
@@ -357,8 +356,6 @@ COM_StatusTypeDef Ymodem_Receive(uint32_t *puSize, uint32_t uFlashDestination)
           else
           {
             Serial_PutByte(CRC16); /* Ask for a packet */
-            /* Replace C char by . on display console */
-            COM_Transmit_Y((uint8_t *)BACK_SLASH_POINT, sizeof(BACK_SLASH_POINT)-1, TX_TIMEOUT);
           }
           break;
       }

--- a/Projects/B-U585I-IOT02A/Applications/SBSFU/SBSFU_Loader/NonSecure/Src/ymodem.c
+++ b/Projects/B-U585I-IOT02A/Applications/SBSFU/SBSFU_Loader/NonSecure/Src/ymodem.c
@@ -35,7 +35,6 @@
 #include "main.h"
 
 /* Private const -------------------------------------------------------------*/
-const char BACK_SLASH_POINT[]="\b.";
 /* Private typedef -----------------------------------------------------------*/
 /* Private define ------------------------------------------------------------*/
 /* Private macro -------------------------------------------------------------*/
@@ -357,8 +356,6 @@ COM_StatusTypeDef Ymodem_Receive(uint32_t *puSize, uint32_t uFlashDestination)
           else
           {
             Serial_PutByte(CRC16); /* Ask for a packet */
-            /* Replace C char by . on display console */
-            COM_Transmit_Y((uint8_t *)BACK_SLASH_POINT, sizeof(BACK_SLASH_POINT)-1, TX_TIMEOUT);
           }
           break;
       }


### PR DESCRIPTION
This patch enables the use of lrzsz (https://www.ohse.de/uwe/software/lrzsz.html) utilities —  GNU reference implementation of the x/y/zmodem protocols — with the SBSFU project for transferring update artifacts.
lrzsz provides the sb command used in minicom.
This patch is backward compatible with tera term (https://teratermproject.github.io/index-en.html) — utility referenced in the ST documents for transferring update artifacts.